### PR TITLE
fix: fix multiple CVEs for curl 8.11.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+curl (8.11.0-0deepin2) unstable; urgency=high
+
+  * Fix multiple CVEs for curl 8.11.0
+    - CVE-2025-0167: netrc default with no credentials
+    - CVE-2025-10148: WebSocket mask reuse vulnerability
+    - CVE-2025-13034: QUIC TLS GnuTLS verification bypass
+    - CVE-2026-3783: OAuth2 bearer token leak on redirect
+    - CVE-2026-3784: Proxy credential reuse vulnerability
+
+ -- lichenggang <lichenggang@uniontech.com>  Tue, 21 Apr 2026 21:44:48 +0800
+
 curl (8.11.0-0deepin1) unstable; urgency=medium
 
   [ Samuel Henrique ]

--- a/debian/patches/cve-2025-0167.patch
+++ b/debian/patches/cve-2025-0167.patch
@@ -1,0 +1,29 @@
+Description: netrc: 'default' with no credentials is not a match
+ When parsing a .netrc file, if a 'default' entry with no credentials
+ was encountered, the previous logic did not properly treat it as a
+ missing credential match. This could cause the password from the
+ initial request to be carried over and sent to a redirected host.
+Origin: upstream, https://github.com/curl/curl/commit/0e120c5b925e8ca75d5319e319e5ce4b8080d8eb
+Forwarded: not-needed
+Bug: https://curl.se/docs/CVE-2025-0167.html
+
+--- a/lib/netrc.c
++++ b/lib/netrc.c
+@@ -294,6 +294,17 @@ static int parsenetrc(struct store_netrc *store,
+
+ out:
+   Curl_dyn_free(&token);
++  if(!retcode) {
++    if(!password && our_login) {
++      /* success without a password, set a blank one */
++      password = strdup("");
++      if(!password)
++        retcode = 1; /* out of memory */
++    }
++    else if(!login && !password)
++      /* a default with no credentials */
++      retcode = NETRC_FILE_MISSING;
++  }
+   if(!retcode) {
+     /* success */
+     if(login_alloc) {

--- a/debian/patches/cve-2025-10148.patch
+++ b/debian/patches/cve-2025-10148.patch
@@ -1,0 +1,52 @@
+Description: ws: get a new mask for each new outgoing frame
+ curl's code generated the WebSocket mask only once during connection
+ setup and reused it for all subsequent frames. Per RFC 6455, every
+ client-to-server WebSocket frame must be masked with a new, randomly
+ generated 32-bit mask. This fix moves mask generation into the frame
+ encoding function so that a fresh mask is generated for every outgoing
+ frame.
+Origin: upstream, https://github.com/curl/curl/commit/84db7a9eae8468c0445b15aa806fa7fa806fa0f2
+Forwarded: not-needed
+Bug: https://curl.se/docs/CVE-2025-10148.html
+
+--- a/lib/ws.c
++++ b/lib/ws.c
+@@ -547,6 +547,7 @@ static ssize_t ws_enc_write_head(struct Curl_easy *data,
+   unsigned char head[14];
+   size_t hlen;
+   ssize_t n;
++  CURLcode result;
+
+   if(payload_len < 0) {
+     failf(data, "WS: starting new frame with negative payload length %"
+@@ -618,6 +619,14 @@ static ssize_t ws_enc_write_head(struct Curl_easy *data,
+   enc->payload_remain = enc->payload_len = payload_len;
+   ws_enc_info(enc, data, "sending");
+
++  /* 4 bytes random */
++
++  result = Curl_rand(data, (unsigned char *)&enc->mask, sizeof(enc->mask));
++  if(result) {
++    *err = result;
++    return -1;
++  }
++
+   /* add 4 bytes mask */
+   memcpy(&head[hlen], &enc->mask, 4);
+   hlen += 4;
+@@ -808,14 +817,7 @@ CURLcode Curl_ws_accept(struct Curl_easy *data,
+      subprotocol not requested by the client), the client MUST Fail
+      the WebSocket Connection. */
+
+-  /* 4 bytes random */
+-
+-  result = Curl_rand(data, (unsigned char *)&ws->enc.mask,
+-                     sizeof(ws->enc.mask));
+-  if(result)
+-    return result;
+-  infof(data, "Received 101, switch to WebSocket; mask %02x%02x%02x%02x",
+-        ws->enc.mask[0], ws->enc.mask[1], ws->enc.mask[2], ws->enc.mask[3]);
++  infof(data, "Received 101, switch to WebSocket");
+
+   /* Install our client writer that decodes WS frames payload */
+   result = Curl_cwriter_create(&ws_dec_writer, data, &ws_cw_decode,

--- a/debian/patches/cve-2025-13034.patch
+++ b/debian/patches/cve-2025-13034.patch
@@ -1,0 +1,31 @@
+Description: vquic-tls/gnutls: call Curl_gtls_verifyserver unconditionally
+ When using QUIC with ngtcp2 built with GnuTLS, the public key pinning
+ check (Curl_gtls_verifyserver) was skipped if standard certificate
+ verification was disabled. This allowed connections to malicious servers
+ to succeed without the pinning check, enabling man-in-the-middle attacks
+ even when pinning was configured.
+Origin: upstream, https://github.com/curl/curl/commit/3d91ca8cdb3b434226e743946d428b4dd3acf2c9
+Forwarded: not-needed
+Bug: https://curl.se/docs/CVE-2025-13034.html
+
+--- a/lib/vquic/vquic-tls.c
++++ b/lib/vquic/vquic-tls.c
+@@ -325,13 +325,11 @@ CURLcode Curl_vquic_tls_verify_peer(struct curl_tls_ctx *ctx,
+   (void)conn_config;
+   result = Curl_oss_check_peer_cert(cf, data, &ctx->ossl, peer);
+ #elif defined(USE_GNUTLS)
+-  if(conn_config->verifyhost) {
+-    result = Curl_gtls_verifyserver(data, ctx->gtls.session,
+-                                    conn_config, &data->set.ssl, peer,
+-                                    data->set.str[STRING_SSL_PINNEDPUBLICKEY]);
+-    if(result)
+-      return result;
+-  }
++  result = Curl_gtls_verifyserver(data, ctx->gtls.session,
++                                  conn_config, &data->set.ssl, peer,
++                                  data->set.str[STRING_SSL_PINNEDPUBLICKEY]);
++  if(result)
++    return result;
+ #elif defined(USE_WOLFSSL)
+   (void)data;
+   if(conn_config->verifyhost) {

--- a/debian/patches/cve-2026-3783.patch
+++ b/debian/patches/cve-2026-3783.patch
@@ -1,0 +1,20 @@
+Description: http: do not send OAuth2 bearer token on redirect to different host
+ When an OAuth2 bearer token is used for an HTTP(S) transfer, and that
+ transfer performs a redirect to a second URL, curl could leak that
+ token to the second hostname under some circumstances. This fix adds
+ a Curl_auth_allowed_to_host() check before sending the bearer token
+ to ensure it is only sent to the originally intended host.
+Origin: upstream, https://github.com/curl/curl/commit/e3d7401a32a46516c9e5ee877e613e62ed35bddc
+Forwarded: not-needed
+Bug: https://curl.se/docs/CVE-2026-3783.html
+
+--- a/lib/http.c
++++ b/lib/http.c
+@@ -650,6 +650,7 @@ output_auth_headers(struct Curl_easy *data,
+   if(authstatus->picked == CURLAUTH_BEARER) {
+     /* Bearer */
+     if((!proxy && data->set.str[STRING_BEARER] &&
++       Curl_auth_allowed_to_host(data) &&
+         !Curl_checkheaders(data, STRCONST("Authorization")))) {
+       auth = "Bearer";
+       result = http_output_bearer(data);

--- a/debian/patches/cve-2026-3784.patch
+++ b/debian/patches/cve-2026-3784.patch
@@ -1,0 +1,63 @@
+Description: url: do not reuse connection if SOCKS proxy credentials differ
+ curl would wrongly reuse an existing HTTP proxy connection doing CONNECT
+ to a server, even if the new request uses different credentials for the
+ HTTP proxy. The proper behavior is to create or use a separate connection.
+ This fix merges the credential check into proxy_info_matches() and
+ removes the separate socks_proxy_info_matches() function so that all
+ proxy types check credentials when reusing connections.
+Origin: upstream, https://github.com/curl/curl/commit/5f13a7645e565c5c1a06f3ef86e97afb856fb364
+Forwarded: not-needed
+Bug: https://curl.se/docs/CVE-2026-3784.html
+
+--- a/lib/url.c
++++ b/lib/url.c
+@@ -678,34 +678,18 @@ proxy_info_matches(const struct proxy_info *data,
+ {
+   if((data->proxytype == needle->proxytype) &&
+      (data->port == needle->port) &&
+-     strcasecompare(data->host.name, needle->host.name))
+-    return TRUE;
++     strcasecompare(data->host.name, needle->host.name)) {
+
++    if(Curl_timestrcmp(data->user, needle->user) ||
++       Curl_timestrcmp(data->passwd, needle->passwd))
++      return FALSE;
++    return TRUE;
++  }
+   return FALSE;
+ }
+-
+-static bool
+-socks_proxy_info_matches(const struct proxy_info *data,
+-                         const struct proxy_info *needle)
+-{
+-  if(!proxy_info_matches(data, needle))
+-    return FALSE;
+-
+-  /* the user information is case-sensitive
+-     or at least it is not defined as case-insensitive
+-     see https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.1 */
+-
+-  /* curl_strequal does a case insensitive comparison,
+-     so do not use it here! */
+-  if(Curl_timestrcmp(data->user, needle->user) ||
+-     Curl_timestrcmp(data->passwd, needle->passwd))
+-    return FALSE;
+-  return TRUE;
+-}
+ #else
+ /* disabled, will not get called */
+ #define proxy_info_matches(x,y) FALSE
+-#define socks_proxy_info_matches(x,y) FALSE
+ #endif
+
+ /* A connection has to have been idle for a shorter time than 'maxage_conn'
+@@ -972,7 +956,7 @@ static bool url_match_conn(struct connectdata *conn, void *userdata)
+     return FALSE;
+
+   if(needle->bits.socksproxy &&
+-    !socks_proxy_info_matches(&needle->socks_proxy,
++    !proxy_info_matches(&needle->socks_proxy,
+                               &conn->socks_proxy))
+     return FALSE;
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -9,3 +9,10 @@ setopt_fix_CURLOPT_HTTP_CONTENT_DECODING.patch
 netrc_support_large_file_longer_lines_longer_tokens.patch
 cmdline_ech_md_formatting_cleanups.patch
 libssh_when_using_IPv6_numerical_address_add_brackets.patch
+
+# Security fixes for curl 8.11.0
+cve-2025-0167.patch
+cve-2025-10148.patch
+cve-2025-13034.patch
+cve-2026-3783.patch
+cve-2026-3784.patch


### PR DESCRIPTION
Backport upstream security fixes to curl 8.11.0:
- CVE-2026-3783: OAuth2 bearer token leak on redirect Add Curl_auth_allowed_to_host() check before sending bearer token
- CVE-2026-3784: Proxy credential reuse vulnerability Merge credential check into proxy_info_matches(), remove socks_proxy_info_matches()
- CVE-2025-10148: WebSocket mask reuse vulnerability Generate new mask for each outgoing WebSocket frame
- CVE-2025-0167: netrc default with no credentials Treat 'default' with no credentials as not a match
- CVE-2025-13034: QUIC TLS GnuTLS verification bypass Call Curl_gtls_verifyserver() unconditionally

Log: Fix multiple CVEs for curl 8.11.0 security update

Influence:
1. Verify OAuth2 bearer token is not leaked on cross-host redirect
2. Verify proxy connections with different credentials are not reused
3. Verify WebSocket frames use unique masks per frame
4. Verify netrc 'default' without credentials does not match
5. Verify QUIC TLS peer verification works with GnuTLS

fix: 修复 curl 8.11.0 多个 CVE 安全漏洞

为 curl 8.11.0 回移植上游安全修复补丁：
- CVE-2026-3783: OAuth2 bearer token 重定向泄漏 在发送 bearer token 前增加 Curl_auth_allowed_to_host() 检查
- CVE-2026-3784: 代理凭据重用漏洞 将凭据检查合并到 proxy_info_matches()，移除 socks_proxy_info_matches()
- CVE-2025-10148: WebSocket 掩码重用漏洞 为每个发出的 WebSocket 帧生成新的掩码
- CVE-2025-0167: netrc default 无凭据匹配问题 将无凭据的 'default' 视为不匹配
- CVE-2025-13034: QUIC TLS GnuTLS 验证绕过 无条件调用 Curl_gtls_verifyserver()

Log: 修复 curl 8.11.0 多个 CVE 安全漏洞

Influence:
1. 验证 OAuth2 bearer token 在跨主机重定向时不会泄漏
2. 验证不同凭据的代理连接不会被重用
3. 验证 WebSocket 每帧使用独立掩码
4. 验证 netrc 'default' 无凭据时不匹配
5. 验证 QUIC TLS GnuTLS 对等验证正常工作

repo: curl #zeno/fix-cve