### PR TITLE
fix(curl): CVE-2026-5773 disable SMB connection reuse

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+curl (8.11.0-0deepin4) unstable; urgency=high
+
+  * Fix CVE-2026-5773: SMB connection reuse may use wrong share
+    libcurl might in some circumstances reuse the wrong connection for
+    SMB(S) transfers. Due to a logical error in connection reuse logic,
+    a transfer could wrongfully reuse an existing SMB connection to the
+    same server that was using a different 'share', potentially leading
+    to downloading or uploading data to the wrong location.
+
+ -- deepin-ci-robot <packages@deepin.org>  Tue, 02 Jun 2026 22:30:00 +0800
+
 curl (8.11.0-0deepin3) unstable; urgency=high
 
   * Fix CVE-2026-6276: stale custom cookie host causes cookie leak

--- a/debian/patches/cve-2026-5773.patch
+++ b/debian/patches/cve-2026-5773.patch
@@ -1,0 +1,69 @@
+Description: SMB: disable connection reuse to prevent wrong share reuse
+ libcurl might in some circumstances reuse the wrong connection for
+ SMB(S) transfers. When reusing a connection a range of criteria must
+ be met. Due to a logical error in the code, a network transfer
+ operation that was requested by an application could wrongfully reuse
+ an existing SMB connection to the same server that was using a
+ different 'share' than the new subsequent transfer should. This could
+ in unlucky situations lead to the download of the wrong file or the
+ upload of a file to the wrong place.
+Origin: backport from https://github.com/curl/curl/commit/74a169575d6412dc0ff532acdf94de35a6c2a571
+Bug-Debian: https://security-tracker.debian.org/tracker/CVE-2026-5773
+Forwarded: not-needed
+Last-Update: 2026-06-02
+
+--- a/lib/smb.c
++++ b/lib/smb.c
+@@ -257,6 +257,8 @@
+                        curl_socket_t *socks);
+ static CURLcode smb_parse_url_path(struct Curl_easy *data,
+                                    struct connectdata *conn);
++static CURLcode smb_done(struct Curl_easy *data, CURLcode status,
++                         bool premature);
+ 
+ /*
+  * SMB handler interface
+@@ -265,7 +267,7 @@
+   "smb",                                /* scheme */
+   smb_setup_connection,                 /* setup_connection */
+   smb_do,                               /* do_it */
+-  ZERO_NULL,                            /* done */
++  smb_done,                             /* done */
+   ZERO_NULL,                            /* do_more */
+   smb_connect,                          /* connect_it */
+   smb_connection_state,                 /* connecting */
+@@ -293,7 +295,7 @@
+   "smbs",                               /* scheme */
+   smb_setup_connection,                 /* setup_connection */
+   smb_do,                               /* do_it */
+-  ZERO_NULL,                            /* done */
++  smb_done,                             /* done */
+   ZERO_NULL,                            /* do_more */
+   smb_connect,                          /* connect_it */
+   smb_connection_state,                 /* connecting */
+@@ -1195,5 +1197,25 @@
+   return CURLE_OK;
+ }
+ 
++/*
++ * smb_done() is called when the SMB transfer is complete.
++ *
++ * Disable connection reuse for SMB to prevent using the wrong
++ * share on subsequent requests. SMB connections are not safe to
++ * reuse when different shares are involved.
++ *
++ * This is the backport of the upstream CVE-2026-5773 fix
++ * (commit 74a169575d6412dc0ff532acdf94de35a6c2a571) adapted
++ * for the Curl_handler architecture used in curl 8.x.
++ */
++static CURLcode smb_done(struct Curl_easy *data, CURLcode status,
++                         bool premature)
++{
++  (void)status;
++  (void)premature;
++  connclose(data->conn, "SMB connection reuse disabled");
++  return CURLE_OK;
++}
++
+ #endif /* CURL_DISABLE_SMB && USE_CURL_NTLM_CORE &&
+           SIZEOF_CURL_OFF_T > 4 */

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -17,5 +17,6 @@ cve-2025-13034.patch
 cve-2026-3783.patch
 cve-2026-3784.patch
 
-# Security fix
+# Security fixes
 cve-2026-6276.patch
+cve-2026-5773.patch


### PR DESCRIPTION
## CVE-2026-5773: SMB connection reuse may use wrong share

### 漏洞描述
libcurl might in some circumstances reuse the wrong connection for SMB(S) transfers. When reusing a connection a range of criteria must be met. Due to a logical error in the code, a network transfer operation that was requested by an application could wrongfully reuse an existing SMB connection to the same server that was using a different 'share' than the new subsequent transfer should. This could in unlucky situations lead to the download of the wrong file or the upload of a file to the wrong place.

### 影响版本
curl 7.40.0 ~ 8.19.0 (introduced by commit aec2e865f0)

### 修复方式
Add smb_done() callback that disables connection reuse for SMB(S) connections, preventing them from being returned to the connection pool. This is the backport of the upstream fix (commit 74a169575d6412dc0ff532acdf94de35a6c2a571) adapted for the Curl_handler architecture used in curl 8.11.0.

### 上游修复
https://github.com/curl/curl/commit/74a169575d6412dc0ff532acdf94de35a6c2a571

### 验证状态
- [x] 补丁生成 (debian/patches/cve-2026-5773.patch)
- [x] debian/changelog 已更新
- [x] debian/patches/series 已更新

---

CVE-Id: CVE-2026-5773
Fix-Approach: backport-patch
Co-Authored-By: deepin-ci-robot <packages@deepin.org>
Generated by: CVE-Fixer Agent